### PR TITLE
Permanent subscriptions by default

### DIFF
--- a/pubsub.tf
+++ b/pubsub.tf
@@ -30,6 +30,10 @@ resource "google_pubsub_subscription" "subscription" {
     }
   }
 
+  expiration_policy {
+    ttl = each.value.expiration_letter_policy == null ? "" : each.value.expiration_letter_policy
+  }
+
   dynamic "retry_policy" {
     for_each = each.value.dead_letter_policy == null ? [] : [1]
     iterator = policy

--- a/variables.tf
+++ b/variables.tf
@@ -14,6 +14,7 @@ variable "subscriptions" {
       topic_name            = optional(string)
       max_delivery_attempts = optional(number)
     }))
+    expiration_policy          = optional(string)
     labels                     = optional(map(string))
     message_retention_duration = optional(number)
     retain_acked_messages      = optional(bool)


### PR DESCRIPTION
> [expiration_policy](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/pubsub_subscription#expiration_policy) - (Optional) A policy that specifies the conditions for this subscription's expiration. A subscription is considered active as long as any connected subscriber is successfully consuming messages from the subscription or is issuing operations on the subscription. If expirationPolicy is not set, a default policy with ttl of 31 days will be used. If it is set but ttl is "", the resource never expires. The minimum allowed value for expirationPolicy.ttl is 1 day. Structure is [documented below](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/pubsub_subscription#nested_expiration_policy).

> The `expiration_policy block` supports:
> 
> [ttl](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/pubsub_subscription#ttl) - (Required) Specifies the "time-to-live" duration for an associated resource. The resource expires if it is not active for a period of ttl. If ttl is not set, the associated resource never expires. A duration in seconds with up to nine fractional digits, terminated by 's'. Example - "3.5s".
